### PR TITLE
Do not register tasks when deleting channels

### DIFF
--- a/odk/framework/inc/odkfw_software_channel_plugin.h
+++ b/odk/framework/inc/odkfw_software_channel_plugin.h
@@ -149,7 +149,7 @@ namespace framework
                 }
             }
 
-            getPluginChannels()->synchronize();
+            getPluginChannels()->synchronize(false);
 
             return true;
         }

--- a/odk/framework/inc/odkfw_software_channel_plugin.h
+++ b/odk/framework/inc/odkfw_software_channel_plugin.h
@@ -149,7 +149,8 @@ namespace framework
                 }
             }
 
-            getPluginChannels()->synchronize(false);
+            instance_channels_to_remove.clear();
+            getPluginChannels()->synchronize();
 
             return true;
         }


### PR DESCRIPTION
When deleting an instance of the plugin, `prepareProcessing` and others gets called after the plugin instance has been deleted (deconstructor called). This seems to happen because tasks (`odk::host_msg::ACQUISITION_TASK_ADD` ) are registered again after they have been successfully removed within the call of `deleteChannels`. 

The fix is quite simple: do not register acquisition tasks again after they have been unregistered. 
Took quite a while to figure out what is going on :) 