### PR TITLE
docs/index: Remove SDK version number

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 .. OXYGEN-SDK documentation master file
 
-=======================
-DEWETRON OXYGEN-SDK 6.1
-=======================
+===================
+DEWETRON OXYGEN-SDK
+===================
 
 .. Welcome to Oxygen SDK's documentation!
 .. ======================================


### PR DESCRIPTION
We are backwards compatible anyway, so remove the number to avoid
confusion.