### PR TITLE
Add missing header file to ODK API headers list.

### DIFF
--- a/odk/api/CMakeLists.txt
+++ b/odk/api/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ODK_API_HEADER_FILES
     inc/odkapi_oxygen_queries.h
     inc/odkapi_property_xml.h
     inc/odkapi_property_list_xml.h
+    inc/odkapi_pugixml_fwd.h
     inc/odkapi_software_channel_xml.h
     inc/odkapi_timebase_xml.h
     inc/odkapi_timestamp_xml.h


### PR DESCRIPTION
This file was missing from the headers list, which I ended up needing to properly patch adding `install` commands as described in https://github.com/DEWETRON/OXYGEN-SDK/issues/34. Going through the other libraries, this appears to be the only header file I could find that was missing from each respective `CMakeLists.txt` files.